### PR TITLE
Updating logurs import path to "github.com/sirupsen/logrus"

### DIFF
--- a/bambou/session.go
+++ b/bambou/session.go
@@ -34,7 +34,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 var currentSession Storer


### PR DESCRIPTION
Update the import path to "github.com/sirupsen/logrus" as mandated by
> Everything using logrus will need to use the lower-case: github.com/sirupsen/logrus. Any package that isn't, should be changed